### PR TITLE
Update class-woo-pfand-basic.php

### DIFF
--- a/woo-pfand/trunk/basic/class-woo-pfand-basic.php
+++ b/woo-pfand/trunk/basic/class-woo-pfand-basic.php
@@ -70,7 +70,7 @@ class Woo_Pfand_Basic {
         if( ! $this->display_deposit() )
             return $price_display_suffix;
 
-        $dep_total = $this->get_deposit( $product->id );
+        $dep_total = $this->get_deposit( $product->get_id() );
 
         if( ! empty( $dep_total ) ) {
 


### PR DESCRIPTION
Update to work with woocommerce 3.0. Fix for "Notice: id was called incorrectly."